### PR TITLE
betas parameter in Adam shall not be integers

### DIFF
--- a/train.py
+++ b/train.py
@@ -156,8 +156,8 @@ def main(**kwargs):
     c.G_kwargs = dnnlib.EasyDict(class_name='training.networks.Generator')
     c.D_kwargs = dnnlib.EasyDict(class_name='training.networks.Discriminator')
     
-    c.G_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0,0], eps=1e-8)
-    c.D_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0,0], eps=1e-8)
+    c.G_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0.0, 0.0], eps=1e-8)
+    c.D_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0.0, 0.0], eps=1e-8)
     
     c.loss_kwargs = dnnlib.EasyDict(class_name='training.loss.R3GANLoss')
     c.data_loader_kwargs = dnnlib.EasyDict(pin_memory=True, prefetch_factor=2)

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -328,7 +328,7 @@ def training_loop(
             # Update weights.  
             for g in phase.opt.param_groups:
                 g['lr'] = cur_lr
-                g['betas'] = (0, cur_beta2)
+                g['betas'] = (0.0, cur_beta2)
                       
             with torch.autograd.profiler.record_function(phase.name + '_opt'):
                 params = [param for param in phase.module.parameters() if param.grad is not None]


### PR DESCRIPTION
In PyTorch >= 2.6, the `betas` parameter of the Adam optimizer must explicitly be either a pair of floats or a pair of tensors. 
(See, for example, PR [#134171](https://github.com/pytorch/pytorch/pull/134171) in PyTorch official repo.)

It seems like all we need to make the code run properly in such latest versions of PyTorch is this fix, I had no particular problems after making this change.  